### PR TITLE
Add a limit to report fetching

### DIFF
--- a/puppet_catalog_metrics.rb
+++ b/puppet_catalog_metrics.rb
@@ -25,12 +25,12 @@ if Puppet::Util::Puppetdb.config.respond_to?("server_urls")
   HOST = uri.host
   PORT = uri.port
   catalog_endpoint = "/pdb/query/v4/catalogs"
-  reports_endpoint = "/pdb/query/v4/reports"
+  reports_endpoint = "/pdb/query/v4/reports?limit=100&offset=100"
 else
   HOST = Puppet::Util::Puppetdb.server
   PORT = Puppet::Util::Puppetdb.port
   catalog_endpoint = "/v3/catalogs"
-  reports_endpoint = "/v3/reports"
+  reports_endpoint = "/v3/reports?limit=100&offset=100"
 end
 
 CACERT     = Puppet.settings['localcacert']


### PR DESCRIPTION
* On a PuppetDB instance with a number of reports,
fetching can take a long time and even kill a
PuppetDB instance depending on memory!
* It'll bubble up as an error looking like this:
```
./puppet_catalog_metrics.rb
Average catalog size: 323004 bytes
/opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http/response.rb:364:in `finish': buffer error (Zlib::BufError)
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http/response.rb:364:in `finish'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http/response.rb:265:in `inflater'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http/response.rb:280:in `read_body_0'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http/response.rb:201:in `read_body'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:1134:in `block in get'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:1423:in `block in transport_request'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http/response.rb:162:in `reading_body'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:1422:in `transport_request'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:1384:in `request'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:1377:in `block in request'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:853:in `start'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:1375:in `request'
	from /opt/puppetlabs/puppet/lib/ruby/2.1.0/net/http.rb:1133:in `get'
	from ./puppet_catalog_metrics.rb:48:in `get_endpoint'
	from ./puppet_catalog_metrics.rb:64:in `<main>'
```
* 100 seems like a sweet-spot in my tests